### PR TITLE
I've updated the README to clarify the purpose of the cricket alert e…

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 ![Vuzix Logo](https://apps.vuzix.com/images/vuzix-logo-old.png)
 # Ultralite SDK Sample for Android
-This software is a sample application built using the [Ultralite SDK for Android](https://github.com/Vuzix/ultralite-sdk-android). It shows several example use cases for controlling various types of content on the Vuzix Z100™ smart glasses display.
+This software is a sample application built using the [Ultralite SDK for Android](https://github.com/Vuzix/ultralite-sdk-android). It shows how to implement features for the Vuzix Z100™ smart glasses, with a primary example focused on delivering live cricket scores and alerts.
+
+The cricket alert functionality specifically demonstrates fetching data from external sources (like ESPNCricinfo's RSS feeds and web pages) and presenting this information in a timely manner on the glasses display.
 
 This is intended to allow developers to quickly become familiar with the capabilities of the Ultralite SDK, and learn how to easily add support for the Vuzix Z100™ smart glasses in their own applications.


### PR DESCRIPTION
…xample.

I modified README.md to specify that the primary example within this Ultralite SDK sample application focuses on delivering live cricket scores and alerts to Vuzix Z100 smart glasses.

I also clarified that this involves fetching data from external sources like ESPNCricinfo's RSS feeds and web pages, and presenting this information on the glasses display.